### PR TITLE
Remove single fire timers after they have triggered

### DIFF
--- a/src/Eventually.cpp
+++ b/src/Eventually.cpp
@@ -233,6 +233,10 @@ bool EvtTimeListener::performTriggerAction(EvtContext *c) {
     // On multifire, we shouldn't stop the event chain no matter what, since we are just restarting in this context
     return false;
   } else {
+	  // remove this listener from the chain
+	  // else it will keep triggering each loop
+	  c->removeListener(this);
+
     return returnval;
   }
 }


### PR DESCRIPTION
Single timers were triggering every loop after the fire the first time.